### PR TITLE
looking up and storing team info for botkit storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.start = function (controller, config) {
   beepboop.botByTeamId = function (teamId) {
     // Get a handle on the team's botkit worker/bot
     var resourceId = Object.keys(beepboop.workers).filter(function (key) {
-      var entry = beepboop.workers[key]
+      var entry = beepboop.workers[key] || {}
       return entry.resource && entry.resource.SlackTeamID === teamId
     })[0]
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,21 @@ exports.start = function (controller, config) {
   // expose botkit workers
   beepboop.workers = beepBoopBotkit.workers
 
+  // Returns a botkit bot by Slack team id
+  beepboop.botByTeamId = function (teamId) {
+    // Get a handle on the team's botkit worker/bot
+    var resourceId = Object.keys(beepboop.workers).filter(function (key) {
+      var entry = beepboop.workers[key]
+      return entry.resource && entry.resource.SlackTeamID === teamId
+    })[0]
+
+    if (!resourceId) {
+      return null
+    }
+
+    return beepboop.workers[resourceId].worker
+  }
+
   // return normal beepboop emitter
   return beepboop
 }

--- a/lib/beepboop-botkit.js
+++ b/lib/beepboop-botkit.js
@@ -86,12 +86,29 @@ BeepBoopBotkit.prototype = {
       botResource.worker = this.controller.spawn(botConfig)
       this.workers[botResource.id] = botResource
 
+      // Fire up the RTM
       botResource.worker.startRTM(function (err, bot, payload) {
         if (err) {
           return self.log.error('Could not connect to Slack as bot. Error: ' + err.toString())
         }
 
         self.log.debug(bot.identity.name + ' (' + bot.identity.id + ') started on team ' + bot.team_info.name + ' (' + bot.team_info.id + ')')
+      })
+
+      // Lookup and store team info in botkit storage - needed for slash commands to work
+      self.log.debug('Updating botkit team info for team %s', botConfig['SlackTeamID'])
+      botResource.worker.api.team.info({}, function (err, resp) {
+        if (err) {
+          self.log.error('Error getting team info for team %s: %s', botConfig['SlackTeamID'], err.message)
+          return
+        }
+
+        self.controller.saveTeam(resp.team, function (err, team) {
+          if (err) {
+            self.log.error('Error saving team info for team %s: %s', botConfig['SlackTeamID'], err.message)
+            return
+          }
+        })
       })
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beepboop-botkit",
-  "version": "1.2.0",
+  "version": "1.3.0-rc1",
   "description": "Run a botkit bot on BeepBoopHQ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Slash commands with Botkit don't work if the team isn't stored in the botkit storage.  This PR grabs and stores the team info whenever an `add_resource` event is sent to a process.
